### PR TITLE
fix zlib_decode_so

### DIFF
--- a/manifest.ijs
+++ b/manifest.ijs
@@ -6,7 +6,7 @@ DESCRIPTION=: 0 : 0
 Utilities for zlib
 )
 
-VERSION=: '1.0.8'
+VERSION=: '1.0.9'
 
 RELEASE=: ''
 

--- a/source/run.ijs
+++ b/source/run.ijs
@@ -1,4 +1,4 @@
 NB. run.ijs
 
 load '~Addons/arc/zlib/zlib.ijs'
-load '~Addons/arc/zlib/source/test/test.ijs'
+load '~Addons/arc/zlib/source/test.ijs'

--- a/source/zlibs.ijs
+++ b/source/zlibs.ijs
@@ -43,7 +43,8 @@ else.
   datalen=. , x
 end.
 data=. ({.datalen)#{.a.
-if. 0~: rc=. >@{. cdrc=. zuncompress data;datalen;y;#y do.
+'rc data datalen'=. 3 {. cdrc=. zuncompress data;datalen;y;#y
+if. 0~:rc do.
   if. 0~:x do.
     assert. 0 [ 'zlib uncompression error'
   end.

--- a/zlib.ijs
+++ b/zlib.ijs
@@ -506,7 +506,8 @@ else.
   datalen=. , x
 end.
 data=. ({.datalen)#{.a.
-if. 0~: rc=. >@{. cdrc=. zuncompress data;datalen;y;#y do.
+'rc data datalen'=. 3 {. cdrc=. zuncompress data;datalen;y;#y
+if. 0~:rc do.
   if. 0~:x do.
     assert. 0 [ 'zlib uncompression error'
   end.


### PR DESCRIPTION
I think I hit a bug related to the discussion https://code.jsoftware.com/wiki/Guides/DLLs/Calling_DLLs#J807_Incompatibilities
whereby the result of compressing then decompressing is a bunch of spaces.
```j
   load 'arc/zlib'
   coinsert 'jzlib'
   (NOZLIB ; zlib_decode_j ; zlib_uncompress) zlib_compress 'j programming language'
┌─┬──────────────────────┬────────────────────────────────────────────────────────────┐
│0│j programming language│                                                            │
└─┴──────────────────────┴────────────────────────────────────────────────────────────┘```
```
I get the same results on both linux and darwin builds using j901